### PR TITLE
Support React v15.5+

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import { PropTypes } from 'react';
+import PropTypes from 'prop-types';
 import { requireNativeComponent, View } from 'react-native';
 
 module.exports = requireNativeComponent('RNTBgImage', {


### PR DESCRIPTION
I encountered an error:
```
Fatal Exception: RCTFatalException: Unhandled JS Exception: undefined is not an object (evaluating 'a.PropTypes.string')
```
This error seems to be same as https://github.com/alexnd/react-native-bgimage/issues/3 .

In React v15.5 and later, `PropTypes` needs to be imported from `prop-types` package (not `react`).
See:
https://reactjs.org/blog/2017/04/07/react-v15.5.0.html#migrating-from-reactproptypes